### PR TITLE
Make it work on Firefox.

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -10,5 +10,5 @@
    "minimum_chrome_version": "20.0",
    "name": "rComments for Reddit",
    "permissions": [ "http://reddit.com/*", "https://reddit.com/*", "http://*.reddit.com/*", "https://*.reddit.com/*"],
-   "version": "1.1.5"
+   "version": "1.1.6"
 }

--- a/chrome/rComments.js
+++ b/chrome/rComments.js
@@ -103,10 +103,10 @@
 			data = undefined;
 		}
 		if (window.origin.match(/new\.reddit\.com/)) {
-			if (url[0] === '/') {
-				url = `https://www.reddit.com${url}`;
-			}
 			url = url.replace('new.reddit.com', 'reddit.com');
+		}
+		if (url[0] === '/') {
+			url = `https://www.reddit.com${url}`;
 		}
 		const xhttp = new window.XMLHttpRequest();
 		const promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
There seems to be a difference in how Chrome and FF handle
xmlhttprequests to relative urls.
i.e. /r/foo/comments/bar won't work without https://www.reddit.com
prepended to it.

This small change makes it work in Firefox too (about:debugging -> load temporary extension -> manifest.json to try it) 

[I also signed an xpi for my own use](https://tunguska.dmitry.lol/xpi/rcomments_for_reddit-1.1.6-fx.xpi)

Resolves: #2 